### PR TITLE
Add static frontend serving and SPA routing support

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -3,6 +3,7 @@
 
 const express = require("express");
 const cors = require("cors");
+const path = require("path");
 const app = express();
 const PORT = process.env.PORT || 3001;
 
@@ -149,4 +150,14 @@ console.log(`✅ Backend live at ${process.env.PORT} in ${process.env.NODE_ENV} 
 
 app.get('/api/ping', (req, res) => {
   res.json({ message: 'pong' });
+});
+
+// Serve static frontend
+const staticDir = path.join(__dirname, 'public');
+app.use(express.static(staticDir));
+
+// SPA fallback for non-API routes
+app.get('*', (req, res, next) => {
+  if (req.path.startsWith('/api')) return next();
+  res.sendFile(path.join(staticDir, 'index.html'));
 });


### PR DESCRIPTION
## Purpose
The user was experiencing deployment issues where their backend was live but the frontend wasn't loading properly. They needed help configuring the server to serve both the backend API and frontend static files from a single deployment on Render.

## Code changes
- Added `path` module import for file path handling
- Configured Express to serve static files from a `public` directory
- Implemented SPA (Single Page Application) fallback routing that serves `index.html` for all non-API routes
- Added route protection to ensure API routes (`/api/*`) are not affected by the SPA fallback

This configuration allows the server to handle both API requests and serve the frontend application, resolving the deployment issue where only the backend was accessible.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7c5347055ae7453e9349165e8eaf4df8/pulse-nest)

👀 [Preview Link](https://7c5347055ae7453e9349165e8eaf4df8-pulse-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7c5347055ae7453e9349165e8eaf4df8</projectId>-->
<!--<branchName>pulse-nest</branchName>-->