### PR TITLE
Add default admin user seeding on startup

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -61,6 +61,23 @@ const db = require('./db'); // using pool directly
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;`);
 
     console.log('✅ Database schema ensured.');
+
+    // Seed default admin user if none exists
+    const [admins] = await db.query('SELECT id FROM users WHERE role = "admin" LIMIT 1');
+    if (admins.length === 0) {
+      const bcrypt = require('bcryptjs');
+      const adminName = process.env.DEFAULT_ADMIN_NAME || 'Administrator';
+      const adminEmail = process.env.DEFAULT_ADMIN_EMAIL || 'admin@tasksheet.local';
+      const adminPassword = process.env.DEFAULT_ADMIN_PASSWORD || 'ChangeMeNow!123';
+      const hashed = await bcrypt.hash(adminPassword, 10);
+      await db.query(
+        'INSERT INTO users (name, email, password, role) VALUES (?, ?, ?, ?)',
+        [adminName, adminEmail, hashed, 'admin']
+      );
+      console.log(`🛡️ Default admin created: ${adminEmail}`);
+    } else {
+      console.log('🛡️ Admin user exists.');
+    }
   } catch (e) {
     console.error('❌ Schema initialization error:', e);
   }


### PR DESCRIPTION
## Purpose
The user requested default admin login credentials to be set up automatically. This change ensures that a default administrator account is created when the application starts up if no admin users exist in the database.

## Code changes
- Added automatic admin user seeding logic in the database initialization section
- Checks if any admin users exist in the database on startup
- Creates a default admin user with configurable credentials via environment variables:
  - `DEFAULT_ADMIN_NAME` (defaults to "Administrator")
  - `DEFAULT_ADMIN_EMAIL` (defaults to "admin@tasksheet.local") 
  - `DEFAULT_ADMIN_PASSWORD` (defaults to "ChangeMeNow!123")
- Passwords are properly hashed using bcrypt before storage
- Added console logging to indicate admin creation statusTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/7c5347055ae7453e9349165e8eaf4df8/swoosh-hub)

👀 [Preview Link](https://7c5347055ae7453e9349165e8eaf4df8-swoosh-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7c5347055ae7453e9349165e8eaf4df8</projectId>-->
<!--<branchName>swoosh-hub</branchName>-->